### PR TITLE
Fix project name references and update settings

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn found_it.wsgi
+web: gunicorn cake_it_easy.wsgi

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@
    ```
 
 5. **Update Project Settings**:
-   - In `found_it/settings.py`, update the following:
+   - In `cake_it_easy/settings.py`, update the following:
      - Ensure `DEBUG` is set to `False` for production.
      - Update the `DATABASES` setting with your PostgreSQL/MySQL credentials.
      - Add the URL of your deployed site to `ALLOWED_HOSTS`.
@@ -197,7 +197,7 @@ Deployed on Heroku.
 
 ### Deployment Steps
 1. **Prepare the App for Deployment**:
-   - Update settings in `found_it/settings.py` to use environment variables for production.
+   - Update settings in `cake_it_easy/settings.py` to use environment variables for production.
    - Disable `DEBUG` mode.
    - Ensure static and media files are properly configured (using Cloudinary).
 

--- a/cake_it_easy/asgi.py
+++ b/cake_it_easy/asgi.py
@@ -1,5 +1,5 @@
 """
-ASGI config for found_it project.
+ASGI config for cake_it_easy project.
 
 It exposes the ASGI callable as a module-level variable named ``application``.
 

--- a/cake_it_easy/settings.py
+++ b/cake_it_easy/settings.py
@@ -16,9 +16,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("SECRET_KEY", "fallback_secret_key")
 
 # SECURITY WARNING: Don't run with debug turned on in production!
-DEBUG = True
-
-# os.getenv("DEBUG", "").lower() in ["true", "1"]
+DEBUG = os.getenv("DEBUG", "False").lower() in ["true", "1", "yes"]
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 

--- a/cake_it_easy/urls.py
+++ b/cake_it_easy/urls.py
@@ -1,4 +1,4 @@
-"""found_it URL Configuration
+"""cake_it_easy URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/3.2/topics/http/urls/

--- a/cake_it_easy/wsgi.py
+++ b/cake_it_easy/wsgi.py
@@ -1,5 +1,5 @@
 """
-WSGI config for found_it project.
+WSGI config for cake_it_easy project.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 

--- a/draftREADME.md
+++ b/draftREADME.md
@@ -107,7 +107,7 @@
    ```
 
 5. **Update Project Settings**:
-   - In `found_it/settings.py`, update the following:
+   - In `cake_it_easy/settings.py`, update the following:
      - Ensure `DEBUG` is set to `False` for production.
      - Update the `DATABASES` setting with your PostgreSQL/MySQL credentials.
      - Add the URL of your deployed site to `ALLOWED_HOSTS`.
@@ -192,7 +192,7 @@ Deployed on Heroku.
 
 ### Deployment Steps
 1. **Prepare the App for Deployment**:
-   - Update settings in `found_it/settings.py` to use environment variables for production.
+   - Update settings in `cake_it_easy/settings.py` to use environment variables for production.
    - Disable `DEBUG` mode.
    - Ensure static and media files are properly configured (using Cloudinary).
 

--- a/home/tests.py
+++ b/home/tests.py
@@ -1,3 +1,9 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+class HomePageTests(TestCase):
+    def test_index_page_loads(self):
+        url = reverse("home")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = cake_it_easy.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
## Summary
- update docs and configuration modules to use `cake_it_easy`
- set DEBUG via environment variable
- fix gunicorn command in `Procfile`
- add pytest configuration and a simple homepage test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6847050982e8832b9b8242ab4b00c431